### PR TITLE
fixing issue with MockServer version 3.10.7

### DIFF
--- a/src/test/java/it/HttpTest.java
+++ b/src/test/java/it/HttpTest.java
@@ -17,7 +17,7 @@ import org.mockserver.verify.VerificationTimes;
 
 public class HttpTest {
 	@Rule
-	public MockServerRule mockServerRule = new MockServerRule(this, 9000);
+	public MockServerRule mockServerRule = new MockServerRule(this);
 
 	private MockServerClient mockServerClient;
 
@@ -28,7 +28,7 @@ public class HttpTest {
 
 		// create a GET request using JAX-RS rest client API
 		Client client = ClientBuilder.newClient();
-		Response response = client.target("http://localhost:9000").path("/us/en/foo.extension").request().get();
+		Response response = client.target("http://localhost:" + mockServerRule.getPort()).path("/us/en/foo.extension").request().get();
 
 		// assert response
 		assertThat(response.getStatus(), equalTo(200));
@@ -44,7 +44,7 @@ public class HttpTest {
 
 		// create a GET request using JAX-RS rest client API
 		Client client = ClientBuilder.newClient();
-		Response response = client.target("http://localhost:9000").path("/de/de/foo.extension").request().get();
+		Response response = client.target("http://localhost:" + mockServerRule.getPort()).path("/de/de/foo.extension").request().get();
 
 		// assert response
 		assertThat(response.getStatus(), equalTo(200));


### PR DESCRIPTION
This will fix your particular issue.  The problem is not related to MockServer matching the issue is related to the socket connection from jax-rs being reused across clients so the second test ends up sending requests to the MockServer instance configured from the previous test.

I should be able to improve MockServer to resolve this issue.  However the reason this problem started to appear in version 3.10.7 is because I improved the way MockServer shut down and how the client detects that it has shutdown.  This improvement increased the speed with which the MockServer shutdown so the jax-rs client didn't timeout the socket connect.